### PR TITLE
Revert "Support multiple accounts."

### DIFF
--- a/LinkedIn/Pages/Account.php
+++ b/LinkedIn/Pages/Account.php
@@ -15,34 +15,34 @@
             function getContent()
             {
                 $this->gatekeeper(); // Logged-in users only
-                $login_url = '';
                 if ($linkedin = \Idno\Core\site()->plugins()->get('LinkedIn')) {
                     if (!$linkedin->hasLinkedIn()) {
                         if ($linkedinAPI = $linkedin->connect()) {
                             $login_url = $linkedinAPI->getAuthenticationUrl(
-                                \IdnoPlugins\LinkedIn\Main::$AUTHORIZATION_ENDPOINT,
-                                \IdnoPlugins\LinkedIn\Main::getRedirectUrl(),
-                                ['scope' => 'rw_nus', 'response_type' => 'code', 'state' => \IdnoPlugins\LinkedIn\Main::getState()]
+				\IdnoPlugins\LinkedIn\Main::$AUTHORIZATION_ENDPOINT,
+				\IdnoPlugins\LinkedIn\Main::getRedirectUrl(),
+				['scope' => 'rw_nus', 'response_type' => 'code', 'state' => \IdnoPlugins\LinkedIn\Main::getState()] 
                             );
-
+			    
                         }
+                    } else {
+                        $login_url = '';
                     }
                 }
-                $t    = \Idno\Core\site()->template();
+                $t = \Idno\Core\site()->template();
                 $body = $t->__(['login_url' => $login_url])->draw('account/linkedin');
                 $t->__(['title' => 'LinkedIn', 'body' => $body])->drawPage();
             }
 
-            function postContent()
-            {
+            function postContent() {
                 $this->gatekeeper(); // Logged-in users only
                 if (($this->getInput('remove'))) {
-                    $user           = \Idno\Core\site()->session()->currentUser();
+                    $user = \Idno\Core\site()->session()->currentUser();
                     $user->linkedin = [];
                     $user->save();
                     \Idno\Core\site()->session()->addMessage('Your LinkedIn settings have been removed from your account.');
                 }
-                $this->forward(\Idno\Core\site()->config()->getDisplayURL() . 'account/linkedin/');
+                $this->forward('/account/linkedin/');
             }
 
         }

--- a/LinkedIn/Pages/Callback.php
+++ b/LinkedIn/Pages/Callback.php
@@ -17,25 +17,25 @@
                 $this->gatekeeper(); // Logged-in users only
                 if ($linkedin = \Idno\Core\site()->plugins()->get('LinkedIn')) {
                     if ($linkedinAPI = $linkedin->connect()) {
-
-                        if ($response = $linkedinAPI->getAccessToken(\IdnoPlugins\LinkedIn\Main::$TOKEN_ENDPOINT,
-                            'authorization_code',
-                            ['code' => $this->getInput('code'), 'redirect_uri' => \IdnoPlugins\LinkedIn\Main::getRedirectUrl(), 'state' => \IdnoPlugins\LinkedIn\Main::getState()])
-                        ) {
-
-                            $user           = \Idno\Core\site()->session()->currentUser();
-
-                            $basic_profile = $linkedinAPI->fetch('https://api.linkedin.com/v1/people/~:(id,first-name,last-name,site-standard-profile-request)', array('oauth2_access_token' => $response['result']['access_token'], 'format' => 'json'));
-                            $id = $basic_profile['result']['id'];
-                            $name = $basic_profile['result']['firstName'] . ' ' . $basic_profile['result']['lastName'];
-                            $user->linkedin[$id] = ['access_token' => $response['result']['access_token'], 'name' => $name];
+			
+			if ($response = $linkedinAPI->getAccessToken(\IdnoPlugins\LinkedIn\Main::$TOKEN_ENDPOINT, 
+			    'authorization_code', 
+			    ['code' => $this->getInput('code'), 'redirect_uri' => \IdnoPlugins\LinkedIn\Main::getRedirectUrl(), 'state' => \IdnoPlugins\LinkedIn\Main::getState()])) {
+			    
+			    $user = \Idno\Core\site()->session()->currentUser();
+                            $user->linkedin = ['access_token' => $response['result']['access_token']];
+			    
+			    // Save basic profile info for status updates (because linkedin api is daft)
+			    //$basic_profile = $linkedinAPI->fetch('https://api.linkedin.com/v1/people/~:(id,first-name,last-name,site-standard-profile-request)', array('oauth2_access_token' => $response['result']['access_token'], 'format' => 'json'));
+			    //$user->linkedin['basic_profile'] = $basic_profile;
+			    
                             $user->save();
                             \Idno\Core\site()->session()->addMessage('Your LinkedIn account was connected.');
-
-                        }
+			    
+			}
                     }
                 }
-                $this->forward(\Idno\Core\site()->config()->getDisplayURL() . 'account/linkedin/');
+                $this->forward('/account/linkedin/');
             }
 
         }

--- a/LinkedIn/templates/default/account/linkedin.tpl.php
+++ b/LinkedIn/templates/default/account/linkedin.tpl.php
@@ -8,32 +8,9 @@
 </div>
 <div class="row">
     <div class="span10 offset1">
-        <form action="<?=\Idno\Core\site()->config()->getDisplayURL()?>account/linkedin/" class="form-horizontal" method="post">
+        <form action="/account/linkedin/" class="form-horizontal" method="post">
             <?php
-                if (empty(\Idno\Core\site()->config()->linkedin['appId'])) {
-                    ?>
-                    <div class="control-group">
-                        <div class="controls">
-                            <p>
-                                This site has not been set up to connect to LinkedIn yet.
-                            </p>
-                            <?php
-
-                                if (\Idno\Core\site()->session()->isAdmin()) {
-
-                                ?>
-                                    <p>
-                                        To get started, <a href="<?=\Idno\Core\site()->config()->getDisplayURL()?>admin/linkedin/">click here</a>.
-                                    </p>
-                            <?php
-
-                                }
-
-                            ?>
-                        </div>
-                    </div>
-                    <?php
-                } else if (empty(\Idno\Core\site()->session()->currentUser()->linkedin)) {
+                if (empty(\Idno\Core\site()->session()->currentUser()->linkedin)) {
             ?>
                     <div class="control-group">
                         <div class="controls">
@@ -48,7 +25,7 @@
                     </div>
                 <?php
 
-                } else if (!\Idno\Core\site()->config()->multipleSyndicationAccounts()) {
+                } else {
 
                     ?>
                     <div class="control-group">
@@ -65,40 +42,6 @@
                     </div>
 
                 <?php
-
-                } else {
-
-?>
-                    <div class="control-group">
-                        <div class="controls">
-                            <p class="explanation">
-                                You have connected the following accounts to LinkedIn:
-                            </p>
-                            <?php
-
-                                if ($accounts = \Idno\Core\site()->syndication()->getServiceAccounts('linkedin')) {
-                                    foreach ($accounts as $account) {
-
-                                        ?>
-                                        <p>
-                                            <input type="hidden" name="remove" value="<?= $account['username'] ?>"/>
-                                            <button type="submit"
-                                                    class="btn btn-primary"><?= $account['name'] ?> (click to remove)</button>
-                                        </p>
-                                    <?php
-
-                                    }
-
-                                }
-
-                            ?>
-                            <p>
-                                <a href="<?= $vars['login_url'] ?>" class="">Click here
-                                    to connect another LinkedIn account</a>
-                            </p>
-                        </div>
-                    </div>
-<?php
 
                 }
             ?>

--- a/LinkedIn/templates/default/admin/linkedin.tpl.php
+++ b/LinkedIn/templates/default/admin/linkedin.tpl.php
@@ -23,9 +23,9 @@
                 </div>
             </div>
             <div class="control-group">
-                <label class="control-label" for="name">API Key</label>
+                <label class="control-label" for="name">App Key</label>
                 <div class="controls">
-                    <input type="text" id="name" placeholder="API Key" class="span4" name="appId" value="<?=htmlspecialchars(\Idno\Core\site()->config()->linkedin['appId'])?>" >
+                    <input type="text" id="name" placeholder="App Key" class="span4" name="appId" value="<?=htmlspecialchars(\Idno\Core\site()->config()->linkedin['appId'])?>" >
                 </div>
             </div>
             <div class="control-group">


### PR DESCRIPTION
@benwerd I'm going to revert these changes for now as #1 appears to be incomplete (and looking at the code for the twitter/flickr et al plugins it looks very much like you're abandoning multiple account support for free/selfhosted users anyway).

Issues spotted so far:

* [ ] Migration from old to new doesn't work (account page contains a connect link, but doesn't retrieve a login_url from the API (looks like the logic in Account.php hasn't been migrated to support multiple accounts). 
* [ ] No way to disconnect existing account to start again
* [ ] In Main.php the logic for creating the syndication link never fires (detects the presence of the old acc details, so never displays the new ones
* [ ] The post logic appears to only accept the new format syndication, it doesn't test for the old code (like twitter).

Will happily re-merge once things are working! :)